### PR TITLE
Fixed the computer name not showing up

### DIFF
--- a/main.py
+++ b/main.py
@@ -401,7 +401,8 @@ if not is_started:
             pg.display.flip()
             clockk.tick(fps)
         p2.name=user_name_2
-
+    else:
+        p2.name="Computer"
 
 
     while running:


### PR DESCRIPTION
We can see that , there is an if statement block  from line 381 to 403 for the choice when player has opted for multiplayer and in that statement block it sets the name of other user but there is no condition statement regarding the option for singleplayer mode which is resulting in not showing up the computers name as we have not set the p2.name.

Hence we will simply use else statement and set the name of second player has "Computer".

![image](https://github.com/user-attachments/assets/bcd1f217-9ffa-4f68-8dfd-b78747f3d10c)

------------------------------
else:
   p2.name="Computer"
------------------------------